### PR TITLE
Add in a readonly button.

### DIFF
--- a/env/gutenberg-content.txt
+++ b/env/gutenberg-content.txt
@@ -28,10 +28,6 @@
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
 
-<!-- wp:wporg/download-button -->
-<div class="wp-block-wporg-download-button wp-block-button aligncenter"><a class="wp-block-button__link has-background has-strong-blue-background-color" href="https://wordpress.org/download/" style="color:#fff">Try it Today in WordPress</a></div>
-<!-- /wp:wporg/download-button -->
-
 <!-- wp:paragraph {"align":"center","className":"gutenberg-landing\u002d\u002dbutton-disclaimer","fontSize":"small"} -->
 <p class="has-text-align-center gutenberg-landing--button-disclaimer has-small-font-size"><em>Gutenberg is available as part of WordPress 5.0 and later. The <a href="https://wordpress.org/plugins/classic-editor/">Classic Editor</a> plugin allows users to switch back to the previous editor if needed. Future development will continue in the <a href="https://wordpress.org/plugins/gutenberg/">Gutenberg</a> plugin.</em></p>
 <!-- /wp:paragraph -->
@@ -203,10 +199,6 @@
 <!-- wp:spacer -->
 <div style="height:100px" aria-hidden="true" class="wp-block-spacer"></div>
 <!-- /wp:spacer -->
-
-<!-- wp:wporg/download-button -->
-<div class="wp-block-wporg-download-button wp-block-button aligncenter"><a class="wp-block-button__link has-background has-strong-blue-background-color" href="https://wordpress.org/download/" style="color:#fff">Try it Today in WordPress</a></div>
-<!-- /wp:wporg/download-button -->
 
 <!-- wp:paragraph {"align":"center","className":"gutenberg-landing\u002d\u002dbutton-disclaimer","fontSize":"small"} -->
 <p class="has-text-align-center gutenberg-landing--button-disclaimer has-small-font-size"><em>Gutenberg is available as part of WordPress 5.0 and later. The <a href="https://wordpress.org/plugins/classic-editor/">Classic Editor</a> plugin allows users to switch back to the previous editor if needed. Future development will continue in the <a href="https://wordpress.org/plugins/gutenberg/">Gutenberg</a> plugin.</em></p>

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -7,9 +7,14 @@
  * @package Gutenbergtheme
  */
 
+
 if ( ! defined( 'WPORGPATH' ) ) {
 	define( 'WPORGPATH', get_theme_file_path( '/inc/' ) );
 }
+
+add_action( 'enqueue_block_assets', function () {
+	wp_enqueue_script( 'button-readonly', get_template_directory_uri() . '/js/button-readonly.js', array( 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-block-editor' ), null );
+} );
 
 /**
  * Prevent errors resulting from change to Gutenberg plugin in 4.9 that adds call to
@@ -596,7 +601,6 @@ add_action( 'template_redirect', function() {
 	} );
 
 	add_action( 'enqueue_block_editor_assets', function() {
-		wp_enqueue_script( 'button-readonly', get_template_directory_uri() . '/js/button-readonly.js', array( 'wp-blocks', 'wp-element' ), null );
 		wp_enqueue_style( 'custom-editor-styles', get_template_directory_uri() . '/editor-styles.css', false, '20220406' );
 	} );
 

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -7,13 +7,12 @@
  * @package Gutenbergtheme
  */
 
-
 if ( ! defined( 'WPORGPATH' ) ) {
 	define( 'WPORGPATH', get_theme_file_path( '/inc/' ) );
 }
 
 add_action( 'enqueue_block_assets', function () {
-	wp_enqueue_script( 'button-readonly', get_template_directory_uri() . '/js/button-readonly.js', array( 'wp-blocks', 'wp-element', 'wp-i18n', 'wp-block-editor' ), null );
+	wp_enqueue_script( 'button-readonly', get_template_directory_uri() . '/js/button-readonly.js', array( 'wp-blocks', 'wp-element', 'wp-block-editor' ), null );
 } );
 
 /**

--- a/source/wp-content/themes/wporg-gutenberg/js/button-readonly.js
+++ b/source/wp-content/themes/wporg-gutenberg/js/button-readonly.js
@@ -1,8 +1,9 @@
 var el = wp.element.createElement,
-	registerBlockType = wp.blocks.registerBlockType;
+	registerBlockType = wp.blocks.registerBlockType,
+	InnerBlocks = wp.blockEditor.InnerBlocks;
 
-registerBlockType( 'wporg/download-button', {
-	title: 'Download Gutenberg Button',
+registerBlockType( 'wporg/wporg-gutenberg-button', {
+	title: 'Demo Button',
 	icon: 'button',
 	category: 'layout',
 
@@ -21,46 +22,23 @@ registerBlockType( 'wporg/download-button', {
 			source: 'text',
 			selector: 'a',
 		},
-		align: {
-			type: 'string',
-			default: 'center',
+	},
+
+	edit: function ( props ) {
+		if ( ! window.location.pathname.includes( 'wp-admin' ) ) {
+			var blockEditorData = wp.data.select( 'core/block-editor' );
+			var innerHtml = blockEditorData.getBlock( props.clientId ).innerBlocks[ 0 ].originalContent;
+
+			return el( 'div', { dangerouslySetInnerHTML: { __html: innerHtml } } );
 		}
+
+		return el( InnerBlocks, {
+			template: [ [ 'core/button' ] ],
+			templateLock: 'all',
+		} );
 	},
 
-	supports: {
-		inserter: false
-	},
-
-	edit: function( props ) {
-
-		return el(
-			'div',
-			{ className: 'wp-block-button align' + props.attributes.align, },
-			el(
-				'a',
-				{ className: 'wp-block-button__link has-background has-strong-blue-background-color', href: props.attributes.url,
-					style: { backgroundColor: 'rgb(0,115,170)', color: '#fff' },
-					title: props.attributes.title
-				},
-				props.attributes.text
-			)
-		);
-	},
-
-	save: function( props ) {
-
-		return el(
-			'div',
-			{ className: 'wp-block-button align' + props.attributes.align },
-			el(
-				'a',
-				{ className: 'wp-block-button__link has-background has-strong-blue-background-color', href: props.attributes.url,
-					style: { backgroundColor: 'rgb(0,115,170)', color: '#fff' },
-					title: props.attributes.title
-				},
-				props.attributes.text
-			)
-		);
+	save: function ( props ) {
+		return el( 'div', { className: 'wp-block-buttons' }, el( InnerBlocks.Content ) );
 	},
 } );
-


### PR DESCRIPTION
The custom [ReadOnly button](https://github.com/WordPress/wordpress.org/blob/trunk/wordpress.org/public_html/wp-content/themes/pub/gutenberg/js/button-readonly.js) was created to allow users to navigate away from the block editor instead of triggering the RichText control that you would typically get with a button.

We now want to move that injected content, into the page to allow admins to adjust the content which introduces the problem that there are 2 contexts in which the editor is being used.

1. Unauthenticated users
2. Site admins

This PR  does the following:
 - IF URL contains `wp-admin`  (ie: site admins editing the document to publish an update)
   - Use InnerBlock & a template to render a `core/button` as a child.  
 -  Else: 
    -  Render the InnerBlock content

## Why this approach?
What I really wanted to do is include the default `core/button` block without using `InnerBlock`. I'm not sure how to do that or whether it's possible. I feel like it should be possible and I'm not thinking straight at the moment .🤷

Using it as an InnerBlock was the best second option because I don't want to have to create a custom button... But creating one is an alternative.

I don't like using the InnerBlock component because the `InnerBlock.Content` does not appear available when used within the Block Editor. Because of this, I was forced to _dangerously_ inject the HTML content. I'm not certain it's dangerous in this context because the content would have to already be compromised.

This also isn't great because this only works when the template has 1 block. If we were to have multiple blocks in the template, it would not render all of the children properly because each block has `originalContent` that only includes content for the specific block. 

Another alternative that was mentioned is just to let site admins edit as HTML. 🤔 