### PR TITLE
Remove editor experience when using handheld devices

### DIFF
--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -326,7 +326,7 @@ if ( ! function_exists( 'gutenberg_editor_scripts_and_styles' ) ) {
 
 		if ( wp_is_mobile() ) {
 			$block_editor_css = get_block_editor_theme_styles()[0]['css'];
-			wp_add_inline_style( 'wp-edit-post', $block_editor_css . '.wp-site-blocks{all: unset;}' );
+			wp_add_inline_style( 'wp-edit-post', $block_editor_css . '.wp-site-blocks{all:unset;} body{font-size:inherit;} h1,h2,h3,h4,h5,h6{font-weight:inherit;}' );
 		}
 		/**
 		 * Fires after block assets have been enqueued for the editing interface.

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -440,6 +440,10 @@ add_action(
 				wp_enqueue_style( 'admin-bar' );
 				wp_enqueue_style( 'l10n' );
 
+				if ( wp_is_mobile() ) {
+					return;
+				}
+
 				$post = get_post();
 
 				// Temporarily hardcode content
@@ -505,6 +509,10 @@ add_action(
 		add_action(
 			'enqueue_block_editor_assets',
 			function() {
+				if ( wp_is_mobile() ) {
+					return;
+				}
+
 				wp_enqueue_script( 'plugin-w-button-js', get_stylesheet_directory_uri() . '/plugins/w-button/index.js', array( 'wp-blocks', 'wp-edit-post', 'wp-plugins', 'wp-components' ), filemtime( __DIR__ . '/plugins/w-button/index.js' ) );
 				wp_enqueue_style( 'plugin-w-button-css', get_stylesheet_directory_uri() . '/plugins/w-button/style.css', null, filemtime( __DIR__ . '/plugins/w-button/style.css' ) );
 

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -51,10 +51,11 @@ if ( ! function_exists( 'gutenberg_editor_scripts_and_styles' ) ) {
 			/**
 			 * Styles
 			 */
+			wp_enqueue_style( 'custom-mobile-styles', get_stylesheet_directory_uri() . '/style-mobile.css', false, filemtime( __DIR__ . '/style-mobile.css' ) );
 			$block_editor_css = get_block_editor_theme_styles()[0]['css'];
 			wp_add_inline_style(
-				'wp-edit-post',
-				$block_editor_css . 'body,p{font-size:inherit;} h1,h2,h3,h4,h5,h6{font-weight:inherit;} .wp-block-button__link{border-radius: var(--wp--custom--button--border--radius);}'
+				'custom-mobile-styles',
+				$block_editor_css
 			);
 		} else {
 			// Enqueue heartbeat separately as an "optional" dependency of the editor.

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -271,14 +271,14 @@ if ( ! function_exists( 'gutenberg_editor_scripts_and_styles' ) ) {
 			$editor_settings = get_block_editor_settings( $editor_settings, $editor_context );
 
 			$init_script = <<<JS
-	( function() {
-		window._wpLoadBlockEditor = new Promise( function( resolve ) {
-			wp.domReady( function() {
-				resolve( wp.editPost.initializeEditor( 'editor', "%s", %d, %s, %s ) );
-			} );
-		} );
-	} )();
-	JS;
+			( function() {
+				window._wpLoadBlockEditor = new Promise( function( resolve ) {
+					wp.domReady( function() {
+						resolve( wp.editPost.initializeEditor( 'editor', "%s", %d, %s, %s ) );
+					} );
+				} );
+			} )();
+			JS;
 
 			$script = sprintf(
 				$init_script,

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -326,7 +326,7 @@ if ( ! function_exists( 'gutenberg_editor_scripts_and_styles' ) ) {
 
 		if ( wp_is_mobile() ) {
 			$block_editor_css = get_block_editor_theme_styles()[0]['css'];
-			wp_add_inline_style( 'wp-edit-post', $block_editor_css );
+			wp_add_inline_style( 'wp-edit-post', $block_editor_css . '.wp-site-blocks{all: unset;}' );
 		}
 		/**
 		 * Fires after block assets have been enqueued for the editing interface.

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -444,7 +444,7 @@ add_action(
 										'title'          => array( 'raw' => $temporary_content['title'] ),
 										'content'        => array(
 											'block_format' => 1,
-											'raw'          => $temporary_content['content']
+											'raw'          => $temporary_content['content'],
 										),
 										'excerpt'        => array( 'raw' => '' ),
 										'date'           => '',

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -41,7 +41,7 @@ if ( ! function_exists( 'gutenberg_editor_scripts_and_styles' ) ) {
 			/**
 			 * Scripts
 			 */
-			$temporary_content = include __DIR__ . '/gutenberg-content.php';
+			$temporary_content = include __DIR__ . '/gutenberg-content-mobile.php';
 			$script            = sprintf(
 				'wp.domReady( function () { document.querySelector(".wp-site-blocks").innerHTML = %s } );',
 				wp_json_encode( do_blocks( $temporary_content['content'] ) )

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -37,253 +37,258 @@ if ( ! function_exists( 'gutenberg_editor_scripts_and_styles' ) ) {
 	 */
 	function gutenberg_editor_scripts_and_styles( $hook ) {
 
-		// Enqueue heartbeat separately as an "optional" dependency of the editor.
-		// Heartbeat is used for automatic nonce refreshing, but some hosts choose
-		// to disable it outright.
-		wp_enqueue_script( 'heartbeat' );
-
-		global $post;
-
-		// Set initial title to empty string for auto draft for duration of edit.
-		// Otherwise, title defaults to and displays as "Auto Draft".
-		$is_new_post = 'auto-draft' === $post->post_status;
-
-		// Set the post type name.
-		$post_type        = get_post_type( $post );
-		$post_type_object = get_post_type_object( $post_type );
-		$rest_base        = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
-
-		$preload_paths = array(
-			'/',
-			'/wp/v2/types?context=edit',
-			'/wp/v2/taxonomies?per_page=-1&context=edit',
-			'/wp/v2/themes?status=active',
-			sprintf( '/wp/v2/%s/%s?context=edit', $rest_base, $post->ID ),
-			sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
-			sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
-			array( '/wp/v2/media', 'OPTIONS' ),
-			array( '/wp/v2/blocks', 'OPTIONS' ),
-		);
-
-		/**
-		 * Preload common data by specifying an array of REST API paths that will be preloaded.
-		 *
-		 * Filters the array of paths that will be preloaded.
-		 *
-		 * @param array $preload_paths Array of paths to preload
-		 * @param object $post         The post resource data.
-		 */
-		$preload_paths = apply_filters( 'block_editor_preload_paths', $preload_paths, $post );
-
-		// Ensure the global $post remains the same after
-		// API data is preloaded. Because API preloading
-		// can call the_content and other filters, callbacks
-		// can unexpectedly modify $post resulting in issues
-		// like https://github.com/WordPress/gutenberg/issues/7468.
-		$backup_global_post = $post;
-
-		$preload_data = array_reduce(
-			$preload_paths,
-			'rest_preload_api_request',
-			array()
-		);
-
-		// Restore the global $post as it was before API preloading.
-		$post = $backup_global_post;
-
-		wp_add_inline_script(
-			'wp-api-fetch',
-			sprintf( 'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );', wp_json_encode( $preload_data ) ),
-			'after'
-		);
-
-		wp_add_inline_script(
-			'wp-blocks',
-			sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $post ) ) ),
-			'after'
-		);
-
-		// Assign initial edits, if applicable. These are not initially assigned
-		// to the persisted post, but should be included in its save payload.
-		if ( $is_new_post ) {
-			// Override "(Auto Draft)" new post default title with empty string,
-			// or filtered value.
-			$initial_edits = array(
-				'title'   => $post->post_title,
-				'content' => $post->post_content,
-				'excerpt' => $post->post_excerpt,
-			);
+		if ( wp_is_mobile() ) {
+			$temporary_content = include __DIR__ . '/gutenberg-content.php';
+			echo( do_blocks( $temporary_content['content'] ) );
 		} else {
-			$initial_edits = null;
-		}
+			// Enqueue heartbeat separately as an "optional" dependency of the editor.
+			// Heartbeat is used for automatic nonce refreshing, but some hosts choose
+			// to disable it outright.
+			wp_enqueue_script( 'heartbeat' );
 
-		// Preload server-registered block schemas.
-		wp_add_inline_script(
-			'wp-blocks',
-			'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . json_encode( get_block_editor_server_block_settings() ) . ');'
-		);
+			global $post;
 
-		/**
-		 * Filters the allowed block types for the editor, defaulting to true (all
-		 * block types supported).
-		 *
-		 * @param bool|array $allowed_block_types Array of block type slugs, or
-		 *                                        boolean to enable/disable all.
-		 * @param object $post                    The post resource data.
-		 */
-		$allowed_block_types = apply_filters( 'allowed_block_types', true, $post );
+			// Set initial title to empty string for auto draft for duration of edit.
+			// Otherwise, title defaults to and displays as "Auto Draft".
+			$is_new_post = 'auto-draft' === $post->post_status;
 
-		// Get all available templates for the post/page attributes meta-box.
-		// The "Default template" array element should only be added if the array is
-		// not empty so we do not trigger the template select element without any options
-		// besides the default value.
-		$available_templates = wp_get_theme()->get_page_templates( get_post( $post->ID ) );
-		$available_templates = ! empty( $available_templates ) ? array_merge(
-			array(
-				'' => apply_filters( 'default_page_template_title', __( 'Default template', 'gutenberg' ), 'rest-api' ),
-			),
-			$available_templates
-		) : $available_templates;
+			// Set the post type name.
+			$post_type        = get_post_type( $post );
+			$post_type_object = get_post_type_object( $post_type );
+			$rest_base        = ! empty( $post_type_object->rest_base ) ? $post_type_object->rest_base : $post_type_object->name;
 
-		// Media settings.
-		$max_upload_size = wp_max_upload_size();
-		if ( ! $max_upload_size ) {
-			$max_upload_size = 0;
-		}
+			$preload_paths = array(
+				'/',
+				'/wp/v2/types?context=edit',
+				'/wp/v2/taxonomies?per_page=-1&context=edit',
+				'/wp/v2/themes?status=active',
+				sprintf( '/wp/v2/%s/%s?context=edit', $rest_base, $post->ID ),
+				sprintf( '/wp/v2/types/%s?context=edit', $post_type ),
+				sprintf( '/wp/v2/users/me?post_type=%s&context=edit', $post_type ),
+				array( '/wp/v2/media', 'OPTIONS' ),
+				array( '/wp/v2/blocks', 'OPTIONS' ),
+			);
 
-		// Editor Styles.
-		global $editor_styles;
-		$styles = array();
-
-		if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
-			foreach ( $editor_styles as $style ) {
-				if ( filter_var( $style, FILTER_VALIDATE_URL ) ) {
-					$styles[] = array(
-						'css' => file_get_contents( $style ),
-					);
-				} else {
-					$file = get_theme_file_path( $style );
-					if ( file_exists( $file ) ) {
-						$styles[] = array(
-							'css'     => file_get_contents( $file ),
-							'baseURL' => get_theme_file_uri( $style ),
-						);
-					}
-				}
-			}
-		}
-
-		// Lock settings.
-		$user_id = wp_check_post_lock( $post->ID );
-		if ( $user_id ) {
 			/**
-			 * Filters whether to show the post locked dialog.
+			 * Preload common data by specifying an array of REST API paths that will be preloaded.
 			 *
-			 * Returning a falsey value to the filter will short-circuit displaying the dialog.
+			 * Filters the array of paths that will be preloaded.
 			 *
-			 * @since 3.6.0
-			 *
-			 * @param bool         $display Whether to display the dialog. Default true.
-			 * @param WP_Post      $post    Post object.
-			 * @param WP_User|bool $user    The user id currently editing the post.
+			 * @param array $preload_paths Array of paths to preload
+			 * @param object $post         The post resource data.
 			 */
-			if ( apply_filters( 'show_post_locked_dialog', true, $post, $user_id ) ) {
-				$locked = true;
+			$preload_paths = apply_filters( 'block_editor_preload_paths', $preload_paths, $post );
+
+			// Ensure the global $post remains the same after
+			// API data is preloaded. Because API preloading
+			// can call the_content and other filters, callbacks
+			// can unexpectedly modify $post resulting in issues
+			// like https://github.com/WordPress/gutenberg/issues/7468.
+			$backup_global_post = $post;
+
+			$preload_data = array_reduce(
+				$preload_paths,
+				'rest_preload_api_request',
+				array()
+			);
+
+			// Restore the global $post as it was before API preloading.
+			$post = $backup_global_post;
+
+			wp_add_inline_script(
+				'wp-api-fetch',
+				sprintf( 'wp.apiFetch.use( wp.apiFetch.createPreloadingMiddleware( %s ) );', wp_json_encode( $preload_data ) ),
+				'after'
+			);
+
+			wp_add_inline_script(
+				'wp-blocks',
+				sprintf( 'wp.blocks.setCategories( %s );', wp_json_encode( get_block_categories( $post ) ) ),
+				'after'
+			);
+
+			// Assign initial edits, if applicable. These are not initially assigned
+			// to the persisted post, but should be included in its save payload.
+			if ( $is_new_post ) {
+				// Override "(Auto Draft)" new post default title with empty string,
+				// or filtered value.
+				$initial_edits = array(
+					'title'   => $post->post_title,
+					'content' => $post->post_content,
+					'excerpt' => $post->post_excerpt,
+				);
 			} else {
-				$locked = false;
+				$initial_edits = null;
 			}
 
-			$user_details = null;
-			if ( $locked ) {
-				$user         = get_userdata( $user_id );
-				$user_details = array(
-					'name' => $user->display_name,
-				);
-				$avatar       = get_avatar( $user_id, 64 );
-				if ( $avatar ) {
-					if ( preg_match( "|src='([^']+)'|", $avatar, $matches ) ) {
-						$user_details['avatar'] = $matches[1];
+			// Preload server-registered block schemas.
+			wp_add_inline_script(
+				'wp-blocks',
+				'wp.blocks.unstable__bootstrapServerSideBlockDefinitions(' . json_encode( get_block_editor_server_block_settings() ) . ');'
+			);
+
+			/**
+			 * Filters the allowed block types for the editor, defaulting to true (all
+			 * block types supported).
+			 *
+			 * @param bool|array $allowed_block_types Array of block type slugs, or
+			 *                                        boolean to enable/disable all.
+			 * @param object $post                    The post resource data.
+			 */
+			$allowed_block_types = apply_filters( 'allowed_block_types', true, $post );
+
+			// Get all available templates for the post/page attributes meta-box.
+			// The "Default template" array element should only be added if the array is
+			// not empty so we do not trigger the template select element without any options
+			// besides the default value.
+			$available_templates = wp_get_theme()->get_page_templates( get_post( $post->ID ) );
+			$available_templates = ! empty( $available_templates ) ? array_merge(
+				array(
+					'' => apply_filters( 'default_page_template_title', __( 'Default template', 'gutenberg' ), 'rest-api' ),
+				),
+				$available_templates
+			) : $available_templates;
+
+			// Media settings.
+			$max_upload_size = wp_max_upload_size();
+			if ( ! $max_upload_size ) {
+				$max_upload_size = 0;
+			}
+
+			// Editor Styles.
+			global $editor_styles;
+			$styles = array();
+
+			if ( $editor_styles && current_theme_supports( 'editor-styles' ) ) {
+				foreach ( $editor_styles as $style ) {
+					if ( filter_var( $style, FILTER_VALIDATE_URL ) ) {
+						$styles[] = array(
+							'css' => file_get_contents( $style ),
+						);
+					} else {
+						$file = get_theme_file_path( $style );
+						if ( file_exists( $file ) ) {
+							$styles[] = array(
+								'css'     => file_get_contents( $file ),
+								'baseURL' => get_theme_file_uri( $style ),
+							);
+						}
 					}
 				}
 			}
 
-			$lock_details = array(
-				'isLocked' => $locked,
-				'user'     => $user_details,
+			// Lock settings.
+			$user_id = wp_check_post_lock( $post->ID );
+			if ( $user_id ) {
+				/**
+				 * Filters whether to show the post locked dialog.
+				 *
+				 * Returning a falsey value to the filter will short-circuit displaying the dialog.
+				 *
+				 * @since 3.6.0
+				 *
+				 * @param bool         $display Whether to display the dialog. Default true.
+				 * @param WP_Post      $post    Post object.
+				 * @param WP_User|bool $user    The user id currently editing the post.
+				 */
+				if ( apply_filters( 'show_post_locked_dialog', true, $post, $user_id ) ) {
+					$locked = true;
+				} else {
+					$locked = false;
+				}
+
+				$user_details = null;
+				if ( $locked ) {
+					$user         = get_userdata( $user_id );
+					$user_details = array(
+						'name' => $user->display_name,
+					);
+					$avatar       = get_avatar( $user_id, 64 );
+					if ( $avatar ) {
+						if ( preg_match( "|src='([^']+)'|", $avatar, $matches ) ) {
+							$user_details['avatar'] = $matches[1];
+						}
+					}
+				}
+
+				$lock_details = array(
+					'isLocked' => $locked,
+					'user'     => $user_details,
+				);
+			} else {
+
+				// Lock the post.
+				$active_post_lock = wp_set_post_lock( $post->ID );
+				$lock_details     = array(
+					'isLocked'       => false,
+					'activePostLock' => esc_attr( implode( ':', $active_post_lock ) ),
+				);
+			}
+
+			$editor_settings = array(
+				'availableTemplates'     => $available_templates,
+				'allowedBlockTypes'      => $allowed_block_types,
+				'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
+				'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
+				'disablePostFormats'     => ! current_theme_supports( 'post-formats' ),
+				'titlePlaceholder'       => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
+				'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Start writing or type / to choose a block', 'gutenberg' ), $post ),
+				'isRTL'                  => is_rtl(),
+				'autosaveInterval'       => 10,
+				'maxUploadFileSize'      => $max_upload_size,
+				'allowedMimeTypes'       => get_allowed_mime_types(),
+				'styles'                 => $styles,
+				'imageSizes'             => gutenberg_get_available_image_sizes(),
+				'richEditingEnabled'     => user_can_richedit(),
+				'fullscreenMode'         => true,
+
+				// Ideally, we'd remove this and rely on a REST API endpoint.
+				'postLock'               => $lock_details,
+				'postLockUtils'          => array(
+					'nonce'       => wp_create_nonce( 'lock-post_' . $post->ID ),
+					'unlockNonce' => wp_create_nonce( 'update-post_' . $post->ID ),
+					'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
+				),
+
+				// Whether or not to load the 'postcustom' meta box is stored as a user meta
+				// field so that we're not always loading its assets.
+				'enableCustomFields'     => (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
 			);
-		} else {
 
-			// Lock the post.
-			$active_post_lock = wp_set_post_lock( $post->ID );
-			$lock_details     = array(
-				'isLocked'       => false,
-				'activePostLock' => esc_attr( implode( ':', $active_post_lock ) ),
-			);
-		}
+			$post_autosave = gutenberg_get_autosave_newer_than_post_save( $post );
+			if ( $post_autosave ) {
+				$editor_settings['autosave'] = array(
+					'editLink' => get_edit_post_link( $post_autosave->ID ),
+				);
+			}
 
-		$editor_settings = array(
-			'availableTemplates'     => $available_templates,
-			'allowedBlockTypes'      => $allowed_block_types,
-			'disableCustomColors'    => get_theme_support( 'disable-custom-colors' ),
-			'disableCustomFontSizes' => get_theme_support( 'disable-custom-font-sizes' ),
-			'disablePostFormats'     => ! current_theme_supports( 'post-formats' ),
-			'titlePlaceholder'       => apply_filters( 'enter_title_here', __( 'Add title', 'gutenberg' ), $post ),
-			'bodyPlaceholder'        => apply_filters( 'write_your_story', __( 'Start writing or type / to choose a block', 'gutenberg' ), $post ),
-			'isRTL'                  => is_rtl(),
-			'autosaveInterval'       => 10,
-			'maxUploadFileSize'      => $max_upload_size,
-			'allowedMimeTypes'       => get_allowed_mime_types(),
-			'styles'                 => $styles,
-			'imageSizes'             => gutenberg_get_available_image_sizes(),
-			'richEditingEnabled'     => user_can_richedit(),
-			'fullscreenMode'         => true,
+			if ( ! empty( $post_type_object->template ) ) {
+				$editor_settings['template']     = $post_type_object->template;
+				$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) ? $post_type_object->template_lock : false;
+			}
 
-			// Ideally, we'd remove this and rely on a REST API endpoint.
-			'postLock'               => $lock_details,
-			'postLockUtils'          => array(
-				'nonce'       => wp_create_nonce( 'lock-post_' . $post->ID ),
-				'unlockNonce' => wp_create_nonce( 'update-post_' . $post->ID ),
-				'ajaxUrl'     => admin_url( 'admin-ajax.php' ),
-			),
+			$editor_context  = new WP_Block_Editor_Context( array( 'post' => $post ) );
+			$editor_settings = get_block_editor_settings( $editor_settings, $editor_context );
 
-			// Whether or not to load the 'postcustom' meta box is stored as a user meta
-			// field so that we're not always loading its assets.
-			'enableCustomFields'     => (bool) get_user_meta( get_current_user_id(), 'enable_custom_fields', true ),
-		);
-
-		$post_autosave = gutenberg_get_autosave_newer_than_post_save( $post );
-		if ( $post_autosave ) {
-			$editor_settings['autosave'] = array(
-				'editLink' => get_edit_post_link( $post_autosave->ID ),
-			);
-		}
-
-		if ( ! empty( $post_type_object->template ) ) {
-			$editor_settings['template']     = $post_type_object->template;
-			$editor_settings['templateLock'] = ! empty( $post_type_object->template_lock ) ? $post_type_object->template_lock : false;
-		}
-
-		$editor_context  = new WP_Block_Editor_Context( array( 'post' => $post ) );
-		$editor_settings = get_block_editor_settings( $editor_settings, $editor_context );
-
-		$init_script = <<<JS
-( function() {
-	window._wpLoadBlockEditor = new Promise( function( resolve ) {
-		wp.domReady( function() {
-			resolve( wp.editPost.initializeEditor( 'editor', "%s", %d, %s, %s ) );
+			$init_script = <<<JS
+	( function() {
+		window._wpLoadBlockEditor = new Promise( function( resolve ) {
+			wp.domReady( function() {
+				resolve( wp.editPost.initializeEditor( 'editor', "%s", %d, %s, %s ) );
+			} );
 		} );
-	} );
-} )();
-JS;
+	} )();
+	JS;
 
-		$script = sprintf(
-			$init_script,
-			$post->post_type,
-			$post->ID,
-			wp_json_encode( $editor_settings ),
-			wp_json_encode( $initial_edits )
-		);
-		wp_add_inline_script( 'wp-edit-post', $script );
+			$script = sprintf(
+				$init_script,
+				$post->post_type,
+				$post->ID,
+				wp_json_encode( $editor_settings ),
+				wp_json_encode( $initial_edits )
+			);
+			wp_add_inline_script( 'wp-edit-post', $script );
+		}
 
 		/**
 		 * Scripts
@@ -319,6 +324,10 @@ JS;
 		wp_enqueue_style( 'global-styles-css-custom-properties' );
 		wp_enqueue_style( 'wp-block-spacer' );
 
+		if ( wp_is_mobile() ) {
+			$block_editor_css = get_block_editor_theme_styles()[0]['css'];
+			wp_add_inline_style( 'wp-edit-post', $block_editor_css );
+		}
 		/**
 		 * Fires after block assets have been enqueued for the editing interface.
 		 *

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -38,8 +38,24 @@ if ( ! function_exists( 'gutenberg_editor_scripts_and_styles' ) ) {
 	function gutenberg_editor_scripts_and_styles( $hook ) {
 
 		if ( wp_is_mobile() ) {
+			/**
+			 * Scripts
+			 */
 			$temporary_content = include __DIR__ . '/gutenberg-content.php';
-			echo( do_blocks( $temporary_content['content'] ) );
+			$script            = sprintf(
+				'wp.domReady( function () { document.querySelector(".wp-site-blocks").innerHTML = %s } );',
+				wp_json_encode( do_blocks( $temporary_content['content'] ) )
+			);
+			wp_add_inline_script( 'wp-edit-post', $script );
+
+			/**
+			 * Styles
+			 */
+			$block_editor_css = get_block_editor_theme_styles()[0]['css'];
+			wp_add_inline_style(
+				'wp-edit-post',
+				$block_editor_css . 'body,p{font-size:inherit;} h1,h2,h3,h4,h5,h6{font-weight:inherit;} .wp-block-button__link{border-radius: var(--wp--custom--button--border--radius);}'
+			);
 		} else {
 			// Enqueue heartbeat separately as an "optional" dependency of the editor.
 			// Heartbeat is used for automatic nonce refreshing, but some hosts choose
@@ -324,10 +340,6 @@ if ( ! function_exists( 'gutenberg_editor_scripts_and_styles' ) ) {
 		wp_enqueue_style( 'global-styles-css-custom-properties' );
 		wp_enqueue_style( 'wp-block-spacer' );
 
-		if ( wp_is_mobile() ) {
-			$block_editor_css = get_block_editor_theme_styles()[0]['css'];
-			wp_add_inline_style( 'wp-edit-post', $block_editor_css . '.wp-site-blocks{all:unset;} body{font-size:inherit;} h1,h2,h3,h4,h5,h6{font-weight:inherit;}' );
-		}
 		/**
 		 * Fires after block assets have been enqueued for the editing interface.
 		 *

--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -288,17 +288,17 @@ if ( ! function_exists( 'gutenberg_editor_scripts_and_styles' ) ) {
 				wp_json_encode( $initial_edits )
 			);
 			wp_add_inline_script( 'wp-edit-post', $script );
-		}
 
-		/**
-		 * Scripts
-		 */
-		wp_enqueue_media(
-			array(
-				'post' => $post->ID,
-			)
-		);
-		wp_enqueue_editor();
+			/**
+			 * Scripts
+			 */
+			wp_enqueue_media(
+				array(
+					'post' => $post->ID,
+				)
+			);
+			wp_enqueue_editor();
+		}
 
 		/**
 		 * Styles

--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
@@ -1,0 +1,549 @@
+<?php
+
+$localised_domain = parse_url( home_url( '/' ), PHP_URL_HOST );
+
+$title = __( 'Say Hello to Gutenberg, the WordPress Editor', 'wporg' );
+
+$content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize":"1200px"}} -->
+<div class="wp-block-group alignfull"><!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|black"}}},"spacing":{"padding":{"bottom":"10%","top":"60px"}}},"className":"site-header","layout":{"type":"flex","orientation":"vertical","justifyContent":"left","flexWrap":"wrap"}} -->
+<div class="wp-block-group site-header has-link-color" style="padding-top:60px;padding-bottom:10%"><!-- wp:image {"id":17,"width":38,"height":38,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022/06/site_icon.png" alt="" class="wp-image-17" width="38" height="38"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group -->
+ 
+<!-- wp:columns {"align":"wide"} -->
+<div class="wp-block-columns alignwide"><!-- wp:column {"width":"60%"} -->
+<div class="wp-block-column" style="flex-basis:60%"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:heading {"level":1,"fontSize":"level-6"} -->
+<h1 class="has-level-6-font-size">' . esc_html__( 'Say Hello to Gutenberg, the WordPress Editor', 'wporg' ) . '</h1>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"level-2"} -->
+<p class="has-level-2-font-size">' . esc_html__( 'Experience the flexibility that blocks allow, whether you’re building your first site or write code for a living.', 'wporg' ) . '</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:wporg/wporg-gutenberg-button -->
+<div class="wp-block-wporg-wporg-gutenberg-button wp-block-buttons"><!-- wp:button {"width":100,"className":"is-style-outline"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline"><a class="wp-block-button__link wp-element-button" href="' . esc_url( "https://{$localised_domain}/download/" ) . '">' . esc_html__( 'Try Gutenberg today in WordPress', 'wporg' ) . '</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:wporg/wporg-gutenberg-button --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"30%"} -->
+<div class="wp-block-column" style="flex-basis:30%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:spacer {"height":"60px"} -->
+<div style="height:60px" aria-hidden="true" class="wp-block-spacer"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"bottom":"60px"}}}} -->
+<div class="wp-block-group" style="padding-bottom:60px"><!-- wp:paragraph {"fontSize":"small"} -->
+<p class="has-small-font-size"><em>' . wp_kses_post( __( 'This page was built with blocks — pieces of content that you can move around.', 'wporg' ) ) . '</em></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group -->
+
+<!-- wp:cover {"url":"https://wordpress.org/gutenberg/files/2022/05/Gradient-Background.png","id":1194,"hasParallax":true,"dimRatio":10,"isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"120px","bottom":"120px"}}}} -->
+<div class="wp-block-cover alignfull is-light has-parallax" style="padding-top:120px;padding-bottom:120px;background-image:url(https://wordpress.org/gutenberg/files/2022/05/Gradient-Background.png)"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-10 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"inherit":false,"wideSize":"1200px"}} -->
+<div class="wp-block-group"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"padding":{"top":"0px","left":"0px","bottom":"30px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-top" style="padding-top:0px;padding-bottom:30px;padding-left:0px"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:image {"id":243,"width":35,"height":35,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022/06/block-media-text.png" alt="" class="wp-image-243" width="35" height="35"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"textColor":"tertiary","fontSize":"medium"} -->
+<p class="has-tertiary-color has-text-color has-medium-font-size">' . esc_html__( 'Create modern layouts with rich content.', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"30px","left":"0px"}}}} -->
+<div class="wp-block-column" style="padding-top:0px;padding-right:0px;padding-bottom:30px;padding-left:0px"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:image {"id":244,"width":36,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022/06/block-gallery.png" alt="" class="wp-image-244" width="36"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"textColor":"tertiary","fontSize":"medium"} -->
+<p class="has-tertiary-color has-text-color has-medium-font-size">' . esc_html__( 'Trust that your editor looks like your website.', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"style":{"spacing":{"padding":{"bottom":"30px"}}}} -->
+<div class="wp-block-column" style="padding-bottom:30px"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:image {"id":242,"width":22,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022/06/mobile.png" alt="" class="wp-image-242" width="22"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"textColor":"tertiary","fontSize":"medium"} -->
+<p class="has-tertiary-color has-text-color has-medium-font-size">' . esc_html__( 'Work across screen sizes and devices.', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"style":{"spacing":{"padding":{"bottom":"30px"}}}} -->
+<div class="wp-block-column" style="padding-bottom:30px"><!-- wp:group {"layout":{"type":"flex","orientation":"vertical"}} -->
+<div class="wp-block-group"><!-- wp:image {"id":241,"width":25,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022//06/plugin.png" alt="" class="wp-image-241" width="25"/></figure>
+<!-- /wp:image -->
+
+<!-- wp:paragraph {"textColor":"tertiary","fontSize":"medium"} -->
+<p class="has-tertiary-color has-text-color has-medium-font-size">' . esc_html__( 'Do more with fewer plugins.', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:cover {"overlayColor":"background","minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"120px","bottom":"120px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:120px;padding-bottom:120px"><span aria-hidden="true" class="wp-block-cover__background has-background-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide", "className":"wporg-gutenberg-block-layout", "layout":{"contentSize":"1200px"}} -->
+<div class="wp-block-group wporg-gutenberg-block-layout alignwide"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}}} -->
+<div class="wp-block-columns" style="padding-top:0px;padding-bottom:0px"><!-- wp:column {"width":"80%"} -->
+<div class="wp-block-column" style="flex-basis:80%"><!-- wp:group {"align":"wide","className":"wporg-gutenberg-block-layout"} -->
+<div class="wp-block-group alignwide wporg-gutenberg-block-layout"><!-- wp:heading {"align":"wide","fontSize":"level-5"} -->
+<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'Be your own builder.', 'wporg' ) . '</h2>
+<!-- /wp:heading -->
+
+<!-- wp:paragraph {"fontSize":"medium"} -->
+<p class="has-medium-font-size">' . esc_html__( 'Blocks allow you to build your own custom posts and pages without any coding knowledge. Here’s a selection of the default blocks included with Gutenberg:', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"5%","className":"wporg-gutenberg-hide-on-mobile"} -->
+<div class="wp-block-column wporg-gutenberg-hide-on-mobile" style="flex-basis:5%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top","width":"25%","style":{"spacing":{"padding":{"top":"10px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-top" style="padding-top:10px;flex-basis:25%"><!-- wp:wporg/wporg-gutenberg-button -->
+<div class="wp-block-wporg-wporg-gutenberg-button wp-block-buttons"><!-- wp:button {"width":100,"className":"is-style-outline"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline"><a class="wp-block-button__link wp-element-button" href="' . esc_url( "https://{$localised_domain}/plugins/browse/block/" ) . '">' . esc_html__( 'Browse all blocks', 'wporg' ) . '</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:wporg/wporg-gutenberg-button --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:spacer {"height":"20px","className":"wporg-gutenberg-hide-on-mobile"} -->
+<div style="height:20px" aria-hidden="true" class="wp-block-spacer wporg-gutenberg-hide-on-mobile"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:columns {"isStackedOnMobile":false,"align":"wide","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}}} -->
+<div class="wp-block-columns alignwide is-not-stacked-on-mobile" style="padding-top:0px;padding-bottom:0px"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1192,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/Paragraph.png" alt="" class="wp-image-1192"/><figcaption>' . esc_html__( 'Paragraph', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1219,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/Heading.png" alt="" class="wp-image-1219"/><figcaption>' . esc_html__( 'Heading', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:columns {"isStackedOnMobile":false,"align":"wide","style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}}} -->
+<div class="wp-block-columns alignwide is-not-stacked-on-mobile" style="padding-top:0px;padding-bottom:0px"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1220,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/Media-Text.png" alt="" class="wp-image-1220"/><figcaption>' . esc_html__( 'Media &amp; Text', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1221,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/Image.png" alt="" class="wp-image-1221"/><figcaption>' . esc_html__( 'Image', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:columns {"isStackedOnMobile":false} -->
+<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":192,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2022/05/Cover-1024x1024.png" alt="" class="wp-image-192"/><figcaption>' . esc_html__( 'Cover', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1222,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/Gallery.png" alt="" class="wp-image-1222"/><figcaption>' . esc_html__( 'Gallery', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}}} -->
+<div class="wp-block-columns alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:columns {"isStackedOnMobile":false} -->
+<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1226,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/Video.png" alt="" class="wp-image-1226"/><figcaption>' . esc_html__( 'Video', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1227,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/Audio.png" alt="" class="wp-image-1227"/><figcaption>' . esc_html__( 'Audio', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:columns {"isStackedOnMobile":false} -->
+<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":225,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2022/05/Collumns.png" alt="" class="wp-image-225"/><figcaption>' . esc_html__( 'Columns', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1229,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/File.png" alt="" class="wp-image-1229"/><figcaption>' . esc_html__( 'File', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:columns {"isStackedOnMobile":false} -->
+<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1230,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/Code.png" alt="" class="wp-image-1230"/><figcaption>' . esc_html__( 'Code', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column -->
+
+<!-- wp:column -->
+<div class="wp-block-column"><!-- wp:image {"id":1231,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image size-full"><img src="https://wordpress.org/gutenberg/files/2022/05/List.png" alt="" class="wp-image-1231"/><figcaption>' . esc_html__( 'List', 'wporg' ) . '</figcaption></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:cover {"customOverlayColor":"#fbfaf7","minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"120px","bottom":"0px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:120px;padding-bottom:0px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#fbfaf7"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"className":"wporg-gutenberg-block-layout","layout":{"contentSize":"1200px"}} -->
+<div class="wp-block-group wporg-gutenberg-block-layout"><!-- wp:columns {"style":{"spacing":{"padding":{"right":"0px","left":"0px"}}}} -->
+<div class="wp-block-columns" style="padding-right:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"top","width":"53%","style":{"spacing":{"padding":{"bottom":"0px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-top" style="padding-bottom:0px;flex-basis:53%"><!-- wp:group {"align":"wide","className":"wporg-gutenberg-block-layout","layout":{"type":"default"}} -->
+<div class="wp-block-group alignwide wporg-gutenberg-block-layout"><!-- wp:heading {"align":"wide","fontSize":"level-5"} -->
+<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'Give your creativity a head start.', 'wporg' ) . '</h2>
+<!-- /wp:heading -->
+
+<!-- wp:spacer {"height":"40px","className":"wporg-gutenberg-hide-on-mobile"} -->
+<div style="height:40px" aria-hidden="true" class="wp-block-spacer wporg-gutenberg-hide-on-mobile"></div>
+<!-- /wp:spacer -->
+
+<!-- wp:paragraph {"fontSize":"level-2"} -->
+<p class="has-level-2-font-size">' . esc_html__( 'Beautiful content doesn’t have to be designed from scratch. Patterns are collections of pre-arranged blocks you can assemble to make your content impactful, meaningful and appealing.', 'wporg' ) . '</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"70%","className":"wporg-gutenberg-block-layout"} -->
+<div class="wp-block-column wporg-gutenberg-block-layout" style="flex-basis:70%"><!-- wp:wporg/wporg-gutenberg-button -->
+<div class="wp-block-wporg-wporg-gutenberg-button wp-block-buttons"><!-- wp:button {"width":100,"style":{"color":{"text":"#ffffff"}, "className":"is-style-fill"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-fill"><a class="wp-block-button__link wp-element-button" href="' . esc_url( "https://{$localised_domain}/patterns/" ) . '" style="color:#ffffff">' . esc_html__( 'Block Pattern Directory', 'wporg' ) . '</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:wporg/wporg-gutenberg-button -->
+
+<!-- wp:wporg/wporg-gutenberg-button -->
+<div class="wp-block-wporg-wporg-gutenberg-button wp-block-buttons"><!-- wp:button {"width":100,"className":"is-style-outline"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://learn.wordpress.org/lesson-plan/how-to-use-wordpress-block-patterns/">' . esc_html__( 'Learn how to create patterns', 'wporg' ) . '</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:wporg/wporg-gutenberg-button --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"30%","className":"wporg-gutenberg-hide-on-mobile"} -->
+<div class="wp-block-column wporg-gutenberg-hide-on-mobile" style="flex-basis:30%"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:spacer {"className":"wporg-gutenberg-hide-on-mobile"} -->
+<div style="height:100px" aria-hidden="true" class="wp-block-spacer wporg-gutenberg-hide-on-mobile"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"2%","className":"wporg-gutenberg-hide-on-mobile"} -->
+<div class="wp-block-column wporg-gutenberg-hide-on-mobile" style="flex-basis:2%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"bottom","width":"55%"} -->
+<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:55%"><!-- wp:image {"id":212,"sizeSlug":"large","linkDestination":"none"} -->
+<figure class="wp-block-image size-large"><img src="https://wordpress.org/gutenberg/files/2022/06/pattern-preview.png" alt="" class="wp-image-212"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:cover {"overlayColor":"background","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"120px","bottom":"120px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:120px;padding-bottom:120px"><span aria-hidden="true" class="wp-block-cover__background has-background-background-color has-background-dim-100 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","className":"wporg-gutenberg-block-layout","layout":{"inherit":false,"contentSize":"1200px"}} -->
+<div class="wp-block-group alignwide wporg-gutenberg-block-layout"><!-- wp:heading {"align":"wide","textColor":"primary","fontSize":"level-5"} -->
+<h2 class="alignwide has-primary-color has-text-color has-level-5-font-size" id="gutenberg-everyone">' . esc_html__( 'Gutenberg ❤️ everyone', 'wporg' ) . '</h2>
+<!-- /wp:heading -->
+
+<!-- wp:group {"style":{"spacing":{"padding":{"top":"60px","right":"0px","left":"0px"}}},"className":"wporg-gutenberg-block-layout","layout":{"inherit":false}} -->
+<div class="wp-block-group wporg-gutenberg-block-layout" style="padding-top:60px;padding-right:0px;padding-left:0px"><!-- wp:columns {"verticalAlignment":"top","align":"wide","style":{"spacing":{"padding":{"top":"15px","bottom":"15px"}}}} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-top" style="padding-top:15px;padding-bottom:15px"><!-- wp:column {"verticalAlignment":"top","layout":{"inherit":false}} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:paragraph {"textColor":"primary","fontSize":"medium"} -->
+<p class="has-primary-color has-text-color has-medium-font-size"><strong>' . esc_html__( 'Created by the community.', 'wporg' ) . '</strong></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"padding":{"right":"30px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-top" style="padding-right:30px"><!-- wp:paragraph {"textColor":"primary"} -->
+<p class="has-primary-color has-text-color">' . esc_html__( 'Built by people from all over the world who work daily, meet weekly, and ship biweekly. You can be a part of it.', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top","width":""} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:wporg/wporg-gutenberg-button -->
+<div class="wp-block-wporg-wporg-gutenberg-button wp-block-buttons"><!-- wp:button {"width":100,"className":"is-style-outline"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://make.wordpress.org/core/handbook/tutorials/navigating-the-community/">' . esc_html__( 'Join the WordPress Community', 'wporg' ) . '</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:wporg/wporg-gutenberg-button --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:separator {"backgroundColor":"primary","className":"alignwide is-style-wide wporg-gutenberg-hide-on-mobile"} -->
+<hr class="wp-block-separator has-text-color has-primary-color has-alpha-channel-opacity has-primary-background-color has-background alignwide is-style-wide wporg-gutenberg-hide-on-mobile"/>
+<!-- /wp:separator -->
+
+<!-- wp:columns {"verticalAlignment":"top","align":"wide","style":{"spacing":{"padding":{"top":"15px","bottom":"15px"}}}} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-top" style="padding-top:15px;padding-bottom:15px"><!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:paragraph {"textColor":"primary","fontSize":"medium"} -->
+<p class="has-primary-color has-text-color has-medium-font-size"><strong>' . esc_html__( 'Built for a great developer experience.', 'wporg' ) . '</strong></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"padding":{"right":"30px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-top" style="padding-right:30px"><!-- wp:paragraph {"textColor":"primary"} -->
+<p class="has-primary-color has-text-color">' . esc_html__( 'Gutenberg lives on GitHub using the WordPress REST API, JavaScript, and React.', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:wporg/wporg-gutenberg-button -->
+<div class="wp-block-wporg-wporg-gutenberg-button wp-block-buttons"><!-- wp:button {"width":100,"className":"is-style-outline"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://developer.wordpress.org/block-editor/explanations/architecture/key-concepts/">' . esc_html__( 'Browse the documentation', 'wporg' ) . '</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:wporg/wporg-gutenberg-button --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:separator {"backgroundColor":"primary","className":"alignwide is-style-wide wporg-gutenberg-hide-on-mobile"} -->
+<hr class="wp-block-separator has-text-color has-primary-color has-alpha-channel-opacity has-primary-background-color has-background alignwide is-style-wide wporg-gutenberg-hide-on-mobile"/>
+<!-- /wp:separator -->
+
+<!-- wp:columns {"verticalAlignment":"top","align":"wide","style":{"spacing":{"padding":{"top":"15px","bottom":"15px"}}}} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-top" style="padding-top:15px;padding-bottom:15px"><!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:paragraph {"textColor":"primary","fontSize":"medium"} -->
+<p class="has-primary-color has-text-color has-medium-font-size"><strong>' . esc_html__( 'Designed for compatibility.', 'wporg' ) . '</strong></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"padding":{"right":"30px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-top" style="padding-right:30px"><!-- wp:paragraph {"textColor":"primary"} -->
+<p class="has-primary-color has-text-color">' . esc_html__( 'Gutenberg recommends migrating features to blocks but supports previous versions.', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top","width":""} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:wporg/wporg-gutenberg-button -->
+<div class="wp-block-wporg-wporg-gutenberg-button wp-block-buttons"><!-- wp:button {"width":100,"className":"is-style-outline"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://developer.wordpress.org/block-editor/explanations/faq/#compatibility">' . esc_html__( 'Learn more about compatibility', 'wporg' ) . '</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:wporg/wporg-gutenberg-button --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:separator {"backgroundColor":"primary","className":"alignwide is-style-wide wporg-gutenberg-hide-on-mobile"} -->
+<hr class="wp-block-separator has-text-color has-primary-color has-alpha-channel-opacity has-primary-background-color has-background alignwide is-style-wide wporg-gutenberg-hide-on-mobile"/>
+<!-- /wp:separator -->
+
+<!-- wp:columns {"verticalAlignment":"top","align":"wide","style":{"spacing":{"padding":{"top":"15px","bottom":"15px"}}}} -->
+<div class="wp-block-columns alignwide are-vertically-aligned-top" style="padding-top:15px;padding-bottom:15px"><!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:paragraph {"textColor":"primary","fontSize":"medium"} -->
+<p class="has-primary-color has-text-color has-medium-font-size"><strong>' . esc_html__( 'Focused on accessibility.', 'wporg' ) . '</strong></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top","style":{"spacing":{"padding":{"right":"30px"}}}} -->
+<div class="wp-block-column is-vertically-aligned-top" style="padding-right:30px"><!-- wp:paragraph {"textColor":"primary"} -->
+<p class="has-primary-color has-text-color">' . esc_html__( 'Designing with and for everyone is at the core of the editor and its future.', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"top"} -->
+<div class="wp-block-column is-vertically-aligned-top"><!-- wp:wporg/wporg-gutenberg-button -->
+<div class="wp-block-wporg-wporg-gutenberg-button wp-block-buttons"><!-- wp:button {"width":100,"className":"is-style-outline"} -->
+<div class="wp-block-button has-custom-width wp-block-button__width-100 is-style-outline"><a class="wp-block-button__link wp-element-button" href="https://make.wordpress.org/accessibility/">' . esc_html__( 'See accessibility improvements', 'wporg' ) . '</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:wporg/wporg-gutenberg-button --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:cover {"customOverlayColor":"#ecf6fa","minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"60px","bottom":"60px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:60px;padding-bottom:60px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ecf6fa"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","layout":{"contentSize":"1200px"}} -->
+<div class="wp-block-group alignwide"><!-- wp:columns {"isStackedOnMobile":false} -->
+<div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column {"width":"80%"} -->
+<div class="wp-block-column" style="flex-basis:80%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"60px"}}},"layout":{"contentSize":""}} -->
+<div class="wp-block-group alignwide" style="padding-bottom:60px"><!-- wp:heading {"align":"wide","fontSize":"level-5"} -->
+<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'New to WordPress?', 'wporg' ) . '</h2>
+<!-- /wp:heading -->
+
+<!-- wp:heading {"align":"wide","style":{"typography":{"lineHeight":0.1}},"fontSize":"level-5"} -->
+<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder" style="line-height:0.1">' . esc_html__( 'No problem.', 'wporg' ) . '</h2>
+<!-- /wp:heading --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"20%","style":{"spacing":{"padding":{"top":"20px"}}}} -->
+<div class="wp-block-column" style="padding-top:20px;flex-basis:20%"><!-- wp:image {"align":"right","id":36,"width":30,"height":30,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image alignright size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022/06/wmark.png" alt="" class="wp-image-36" width="30" height="30"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","bottom":"0px"}}}} -->
+<div class="wp-block-columns" style="padding-top:0px;padding-bottom:0px"><!-- wp:column {"verticalAlignment":"bottom","width":"35%"} -->
+<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:35%"><!-- wp:wporg/wporg-gutenberg-link -->
+<div class="wp-block-wporg-wporg-gutenberg-link"><!-- wp:paragraph {"fontSize":"level-1"} -->
+<p class="has-level-1-font-size">' .
+	sprintf(
+	/* translators: 1: The URL to learn.wordpress.org.  */
+		wp_kses_post( __( 'You can learn all the basics on <a href="%1$s">Learn WordPress</a>, a whole section dedicated to helping you get started.', 'wporg' ) ),
+		esc_url( 'https://learn.wordpress.org' )
+	) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:wporg/wporg-gutenberg-link -->
+
+<!-- wp:spacer {"height":"10px","className":"wporg-gutenberg-hide-on-mobile"} -->
+<div style="height:10px" aria-hidden="true" class="wp-block-spacer wporg-gutenberg-hide-on-mobile"></div>
+<!-- /wp:spacer --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"width":"5%","className":"wporg-gutenberg-hide-on-mobile"} -->
+<div class="wp-block-column wporg-gutenberg-hide-on-mobile" style="flex-basis:5%"></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"bottom","width":"60%"} -->
+<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:60%"><!-- wp:wporg/wporg-gutenberg-link -->
+<div class="wp-block-wporg-wporg-gutenberg-link"><!-- wp:paragraph {"textColor":"secondary","fontSize":"level-3"} -->
+<p class="has-secondary-color has-text-color has-level-3-font-size"><a href="https://learn.wordpress.org/workshop/how-to-install-wordpress/">' . esc_html__( 'How to Install WordPress ↗' ) . '</a><br><a href="https://learn.wordpress.org/workshop/how-to-choose-install-a-theme/">' . esc_html__( 'How to Choose and Install a Theme ↗' ) . '</a><br><a href="https://learn.wordpress.org/workshop/intro-to-block-patterns/">' . esc_html__( 'Intro to Block Patterns ↗' ) . '</a><br><a href="https://learn.wordpress.org/workshop/advanced-layouts-with-the-block-editor/">' . esc_html__( 'Advanced Layouts With the Block Editor ↗' ) . '</a></p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:wporg/wporg-gutenberg-link --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:cover {"customOverlayColor":"#fbfaf7","minHeightUnit":"px","contentPosition":"center center","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"60px","bottom":"60px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:60px;padding-bottom:60px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#fbfaf7"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"contentSize":"1200px"}} -->
+<div class="wp-block-group"><!-- wp:columns {"verticalAlignment":"center","isStackedOnMobile":false,"style":{"spacing":{"padding":{"top":"0px","bottom":"0px","right":"0px","left":"0px"}}}} -->
+<div class="wp-block-columns are-vertically-aligned-center is-not-stacked-on-mobile" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"80%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:80%"><!-- wp:paragraph {"fontSize":"level-2"} -->
+<p class="has-level-2-font-size">' . esc_html__( 'Some more helpful content and places to dig deeper about Gutenberg.', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"center","width":"20%"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:20%"><!-- wp:image {"align":"right","id":1157,"width":85,"height":85,"sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":["#3858e9","#fbfaf7"]}}} -->
+<figure class="wp-block-image alignright size-full is-resized"><img src="https://blockpatterndesigns.mystagingwebsite.com/wp-content/uploads/2021/11/docs.png" alt="" class="wp-image-1157" width="85" height="85"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns -->
+
+<!-- wp:wporg/wporg-gutenberg-link -->
+<div class="wp-block-wporg-wporg-gutenberg-link"><!-- wp:paragraph {"textColor":"secondary","fontSize":"level-3"} -->
+<p class="has-secondary-color has-text-color has-level-3-font-size"> <a href="https://developer.wordpress.org/block-editor/explanations/faq/">' . esc_html__( 'Gutenberg FAQs ↗', 'wporg' ) . '</a><br> <a href="https://wordpress.tv/?s=gutenberg">' . esc_html__( 'WordPress.tv talks about Gutenberg ↗' ) . '</a> <br> <a href="https://developer.wordpress.org/block-editor/contributors/design/#goal-of-gutenberg">' . esc_html__( 'Gutenberg Design Principles ↗' ) . '</a><br> <a href="https://wordpress.org/support/article/wordpress-editor/">' . esc_html__( 'WordPress Editor Documentation ↗' ) . '</a><br> <a href="https://make.wordpress.org/core/2020/05/20/ways-to-keep-up-with-full-site-editing-fse/">' . esc_html__( 'Development Updates ↗' ) . '</a> </p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:wporg/wporg-gutenberg-link --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:cover {"url":"https://wordpress.org/gutenberg/files/2022/05/Gradient-Background-2-1.png","id":1202,"hasParallax":true,"dimRatio":10,"isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"120px","right":"0px","bottom":"120px","left":"0px"}}}} -->
+<div class="wp-block-cover alignfull is-light has-parallax" style="padding-top:120px;padding-right:0px;padding-bottom:120px;padding-left:0px;background-image:url(https://wordpress.org/gutenberg/files/2022/05/Gradient-Background-2-1.png)"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-10 has-background-dim"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"contentSize":"1000px"}} -->
+<div class="wp-block-group"><!-- wp:columns {"style":{"spacing":{"padding":{"top":"0px","bottom":"0px","left":"0px"}}}} -->
+<div class="wp-block-columns" style="padding-top:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"width":"100%","style":{"spacing":{"padding":{"right":"30px","left":"30px"}}}} -->
+<div class="wp-block-column" style="padding-right:30px;padding-left:30px;flex-basis:100%"><!-- wp:paragraph {"align":"center","style":{"typography":{"lineHeight":1.2,"fontStyle":"normal","fontWeight":"300"}},"textColor":"tertiary","fontSize":"level-4"} -->
+<p class="has-text-align-center has-tertiary-color has-text-color has-level-4-font-size" style="font-style:normal;font-weight:300;line-height:1.2">' . esc_html__( '“Gutenberg meets our challenges and opportunities head on while simultaneously benefitting everyone who makes a living working in the WP ecosystem. It’s about a lot more than just blocks.”', 'wporg' ) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group -->
+
+<!-- wp:paragraph {"align":"center","style":{"elements":{"link":{"color":{"text":"var:preset|color|tertiary"}}}},"textColor":"tertiary","fontSize":"small"} -->
+<p class="has-text-align-center has-tertiary-color has-text-color has-link-color has-small-font-size"> — MATT MULLENWEG, IN <a href="https://ma.tt/2017/08/we-called-it-gutenberg-for-a-reason/">MA.TT</a></p>
+<!-- /wp:paragraph --></div></div>
+<!-- /wp:cover -->
+
+<!-- wp:cover {"customOverlayColor":"#ecf6fa","minHeightUnit":"px","isDark":false,"align":"full","style":{"spacing":{"padding":{"top":"60px","bottom":"60px"}}}} -->
+<div class="wp-block-cover alignfull is-light" style="padding-top:60px;padding-bottom:60px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#ecf6fa"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"layout":{"inherit":false,"contentSize":"1200px"}} -->
+<div class="wp-block-group alignwide" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:heading {"align":"wide","style":{"spacing":{"margin":{"top":"0px","right":"0px","bottom":"0px","left":"0px"}}},"fontSize":"level-5"} -->
+<h2 class="alignwide has-level-5-font-size" id="thanks-for-trying-gutenberg" style="margin-top:0px;margin-right:0px;margin-bottom:0px;margin-left:0px">' . esc_html__( 'Thanks for trying Gutenberg!', 'wporg' ) . '</h2>
+<!-- /wp:heading -->
+
+<!-- wp:group {"layout":{"inherit":true}} -->
+<div class="wp-block-group"><!-- wp:columns {"verticalAlignment":"bottom","align":"full","style":{"spacing":{"blockGap":"0px"}}} -->
+<div class="wp-block-columns alignfull are-vertically-aligned-bottom"><!-- wp:column {"verticalAlignment":"bottom","width":"50%"} -->
+<div class="wp-block-column is-vertically-aligned-bottom" style="flex-basis:50%"><!-- wp:columns -->
+<div class="wp-block-columns"><!-- wp:column {"width":"70%"} -->
+<div class="wp-block-column" style="flex-basis:70%"><!-- wp:wporg/wporg-gutenberg-link -->
+<div class="wp-block-wporg-wporg-gutenberg-link"><!-- wp:paragraph {"fontSize":"level-1"} -->
+<p class="has-level-1-font-size">' .
+	sprintf(
+	/* translators: 1: The URL to the Gutenberg plugin.  */
+		wp_kses_post( __( 'Gutenberg is available as part of WordPress 5.0 and later. New developments and experiments will continue in the <a href="%1$s">Gutenberg plugin</a>.', 'wporg' ) ),
+		esc_url( "https://{$localised_domain}/plugins/gutenberg/" )
+	) . '</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:wporg/wporg-gutenberg-link --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"className":"wporg-gutenberg-hide-on-mobile"} -->
+<div class="wp-block-column wporg-gutenberg-hide-on-mobile"></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:column -->
+
+<!-- wp:column {"verticalAlignment":"bottom"} -->
+<div class="wp-block-column is-vertically-aligned-bottom"><!-- wp:group {"style":{"spacing":{"padding":{"top":"30px"}}},"layout":{"type":"flex","flexWrap":"nowrap","justifyContent":"space-between"}} -->
+<div class="wp-block-group" style="padding-top:30px"><!-- wp:wporg/wporg-gutenberg-link -->
+<div class="wp-block-wporg-wporg-gutenberg-link"><!-- wp:paragraph {"align":"right","fontSize":"normal"} -->
+<p class="has-text-align-right has-normal-font-size"><a href="https://twitter.com/WordPress">' . esc_html__( 'Twitter ↗', 'wporg' ) . '<br>
+</a><a href="https://github.com/WordPress/gutenberg">' . esc_html__( 'GitHub ↗', 'wporg' ) . '</a>
+</p>
+<!-- /wp:paragraph --></div>
+<!-- /wp:wporg/wporg-gutenberg-link -->
+
+<!-- wp:image {"align":"right","id":17,"width":38,"height":38,"sizeSlug":"full","linkDestination":"none"} -->
+<figure class="wp-block-image alignright size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022/06/site_icon.png" alt="" class="wp-image-17" width="38" height="38"/></figure>
+<!-- /wp:image --></div>
+<!-- /wp:group --></div>
+<!-- /wp:column --></div>
+<!-- /wp:columns --></div>
+<!-- /wp:group --></div>
+<!-- /wp:group --></div></div>
+<!-- /wp:cover -->';
+
+return compact( 'title', 'content' );

--- a/source/wp-content/themes/wporg-gutenberg/style-mobile.css
+++ b/source/wp-content/themes/wporg-gutenberg/style-mobile.css
@@ -24,7 +24,18 @@ h3 {
 
 .wp-block-button__link {
 	border-radius: var(--wp--custom--button--border--radius);
-	background-color: #32373c;
+	background-color: var(--wp--custom--button--color--background);
+	border-color: var(--wp--custom--button--border--color);
+	border-width: var(--wp--custom--button--border--width);
+	border-style: var(--wp--custom--button--border--style);
+	color: var(--wp--custom--button--color--text);
+	font-size: var(--wp--custom--button--typography--font-size);
+	font-weight: var(--wp--custom--button--typography--font-weight);
+	line-height: var(--wp--custom--button--typography--line-height);
+	padding-top: var(--wp--custom--button--spacing--padding--top);
+	padding-right: var(--wp--custom--button--spacing--padding--right);
+	padding-bottom: var(--wp--custom--button--spacing--padding--bottom);
+	padding-left: var(--wp--custom--button--spacing--padding--left);
 }
 
 /**

--- a/source/wp-content/themes/wporg-gutenberg/style-mobile.css
+++ b/source/wp-content/themes/wporg-gutenberg/style-mobile.css
@@ -6,7 +6,11 @@ html {
 	font-size: 18px;
 }
 
-body,
+body {
+	background-color: var(--wp--preset--color--white) !important;
+	font-size: inherit !important;
+}
+
 p {
 	font-size: inherit !important;
 }
@@ -19,7 +23,7 @@ h3 {
 }
 
 /**
-* We want some styles to be the same across diffrent environments.
+* We want some styles to be the same across different environments.
 */
 
 .wp-block-button__link {
@@ -39,12 +43,13 @@ h3 {
 }
 
 /**
-* We want some links to be underlined.
+* We want some links to be underlined and to have styles consistent with different environments.
 */
 
 p > a {
 	text-decoration: underline !important;
 	text-underline-offset: 0.15em !important;
+	color: var(--wp--custom--color--primary);
 }
 
 /**

--- a/source/wp-content/themes/wporg-gutenberg/style-mobile.css
+++ b/source/wp-content/themes/wporg-gutenberg/style-mobile.css
@@ -1,0 +1,56 @@
+/**
+* We use rem units for fonts to make the page responsive.
+*/
+
+html {
+	font-size: 18px;
+}
+
+body,
+p {
+	font-size: inherit !important;
+}
+
+h1,
+h2,
+h3 {
+	word-break: normal;
+	font-weight: inherit !important;
+}
+
+/**
+* We want some styles to be the same across diffrent environments.
+*/
+
+.wp-block-button__link {
+	border-radius: var(--wp--custom--button--border--radius);
+	background-color: #32373c;
+}
+
+/**
+* We want some links to be underlined.
+*/
+
+p > a {
+	text-decoration: underline !important;
+	text-underline-offset: 0.15em !important;
+}
+
+/**
+* There's some weirdness with flex layouts appearing seemingly out of nowhere.
+* This is a utility class to override it. Add as additional CSS class to block.
+*/
+
+.wporg-gutenberg-block-layout {
+	display: block !important;
+}
+
+.wporg-gutenberg-hide-on-mobile {
+	display: none !important;
+}
+
+@media (min-width: 782px) {
+	.wporg-gutenberg-hide-on-mobile {
+		display: inherit !important;
+	}
+}


### PR DESCRIPTION
Fixes #46 

~The logic can also be placed in the following block to avoid running unnecessary logic, but we have to enqueue the required styles. https://github.com/WordPress/wporg-gutenberg/blob/4690151bf3bce5cf35b45a07e2c80b1de0522a9e/source/wp-content/themes/wporg-gutenberg/functions.php#L478-L487~

## Screencast

https://user-images.githubusercontent.com/18050944/188007700-4b35e296-27ac-4d8d-84f6-167f8a9d45a4.mov

The font-weight of the heading and the border styles of the button are still off,
that's probably because they're no longer in the editor, so the class name `editor-styles-wrapper` doesn't exist anymore.
And the button style in the sandbox is different from the one in local env (sandbox has squared black border)

Do we want the styles to be exactly the same as the original ones?
