### PR TITLE
Fix styles on the handheld devices

### DIFF
--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
@@ -5,8 +5,8 @@ $localised_domain = parse_url( home_url( '/' ), PHP_URL_HOST );
 $title = __( 'Say Hello to Gutenberg, the WordPress Editor', 'wporg' );
 
 $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize":"1200px"}} -->
-<div class="wp-block-group alignfull"><!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|black"}}},"spacing":{"padding":{"bottom":"10%","top":"60px"}}},"className":"site-header","layout":{"type":"flex","orientation":"vertical","justifyContent":"left","flexWrap":"wrap"}} -->
-<div class="wp-block-group site-header has-link-color" style="padding-top:60px;padding-bottom:10%"><!-- wp:image {"id":17,"width":38,"height":38,"sizeSlug":"full","linkDestination":"none"} -->
+<div class="wp-block-group alignfull"><!-- wp:group {"style":{"elements":{"link":{"color":{"text":"var:preset|color|black"}}}},"className":"site-header","layout":{"type":"flex","orientation":"vertical","justifyContent":"left","flexWrap":"wrap"}} -->
+<div class="wp-block-group site-header has-link-color" ><!-- wp:image {"id":17,"width":38,"height":38,"sizeSlug":"full","linkDestination":"none"} -->
 <figure class="wp-block-image size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022/06/site_icon.png" alt="" class="wp-image-17" width="38" height="38"/></figure>
 <!-- /wp:image --></div>
 <!-- /wp:group -->

--- a/source/wp-content/themes/wporg-gutenberg/style-mobile.css
+++ b/source/wp-content/themes/wporg-gutenberg/style-mobile.css
@@ -65,8 +65,17 @@ p > a {
 	display: none !important;
 }
 
+.site-header {
+	padding-top: 106px;
+	padding-bottom: 10%;
+}
+
 @media (min-width: 782px) {
 	.wporg-gutenberg-hide-on-mobile {
 		display: inherit !important;
+	}
+
+	.site-header {
+		padding-top: 92px;
 	}
 }

--- a/source/wp-content/themes/wporg-gutenberg/style-mobile.css
+++ b/source/wp-content/themes/wporg-gutenberg/style-mobile.css
@@ -79,3 +79,7 @@ p > a {
 		padding-top: 92px;
 	}
 }
+
+.wp-site-blocks > * + * {
+	margin-block-start: unset;
+}


### PR DESCRIPTION
This PR fixes the layout of the G icon and unexpected gaps.
1. Add `padding-top` to the G icon.
2. Remove unexpected gaps between blocks.

| Before | After |
| ------ | ------|
| 1. ![Screen Shot 2022-09-14 at 4 43 34 PM](https://user-images.githubusercontent.com/18050944/190106974-d31058e4-7113-4914-aed1-17582e55b01a.png) 2. ![Screen Shot 2022-09-14 at 4 43 41 PM](https://user-images.githubusercontent.com/18050944/190106981-f388285f-3a8a-4eb7-95f7-f798cb392a1a.png) 3. ![Screen Shot 2022-09-14 at 4 45 24 PM](https://user-images.githubusercontent.com/18050944/190106988-3d678ed9-c110-4b00-b1d6-44e84c638198.png) | 1. ![Screen Shot 2022-09-14 at 4 44 18 PM](https://user-images.githubusercontent.com/18050944/190106982-28aa23d8-ae1b-4853-adfd-22c10e578746.png) 2. ![Screen Shot 2022-09-14 at 4 44 26 PM](https://user-images.githubusercontent.com/18050944/190106984-1e900036-2ed1-4d8d-9503-bb0a51660d05.png) 3. ![Screen Shot 2022-09-14 at 4 45 48 PM](https://user-images.githubusercontent.com/18050944/190106993-e2fad1a2-8f40-42b3-bc58-3c7e3a6d2d50.png) |
