### PR TITLE
53 new to wordpress headings update

### DIFF
--- a/env/gutenberg-content.txt
+++ b/env/gutenberg-content.txt
@@ -209,7 +209,7 @@
 <div class="wp-block-group"><!-- wp:columns {"style":{"spacing":{"padding":{"right":"0px","left":"0px"}}}} -->
 <div class="wp-block-columns" style="padding-right:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"top","width":"53%","style":{"spacing":{"padding":{"bottom":"0px"}}}} -->
 <div class="wp-block-column is-vertically-aligned-top" style="padding-bottom:0px;flex-basis:53%"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"4.5rem"}}} -->
-<h2 class="alignwide" id="be-your-own-builder" style="font-size:4.5rem">Give your creativity a head start.</h2>
+<h2 class="alignwide" id="head-start" style="font-size:4.5rem">Give your creativity a head start.</h2>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":"40px","className":"wporg-gutenberg-hide-on-mobile"} -->
@@ -370,7 +370,7 @@
 <div class="wp-block-columns"><!-- wp:column {"width":"90%"} -->
 <div class="wp-block-column" style="flex-basis:90%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"60px"}}},"layout":{"contentSize":""}} -->
 <div class="wp-block-group alignwide" style="padding-bottom:60px"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"4.5rem"}}} -->
-<h2 class="alignwide" id="be-your-own-builder" style="font-size:4.5rem">New to WordPress?<br>No problem.</h2>
+<h2 class="alignwide" id="new-to-wordpress" style="font-size:4.5rem">New to WordPress?<br>No problem.</h2>
 <!-- /wp:heading --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/env/gutenberg-content.txt
+++ b/env/gutenberg-content.txt
@@ -370,11 +370,7 @@
 <div class="wp-block-columns"><!-- wp:column {"width":"90%"} -->
 <div class="wp-block-column" style="flex-basis:90%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"60px"}}},"layout":{"contentSize":""}} -->
 <div class="wp-block-group alignwide" style="padding-bottom:60px"><!-- wp:heading {"align":"wide","style":{"typography":{"fontSize":"4.5rem"}}} -->
-<h2 class="alignwide" id="be-your-own-builder" style="font-size:4.5rem">New to WordPress? </h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading {"align":"wide","style":{"typography":{"lineHeight":"0.1","fontSize":"4.5rem"}}} -->
-<h2 class="alignwide" id="be-your-own-builder" style="font-size:4.5rem;line-height:0.1">No problem.</h2>
+<h2 class="alignwide" id="be-your-own-builder" style="font-size:4.5rem">New to WordPress?<br>No problem.</h2>
 <!-- /wp:heading --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
@@ -408,11 +408,7 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column {"width":"80%"} -->
 <div class="wp-block-column" style="flex-basis:80%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"60px"}}},"layout":{"contentSize":""}} -->
 <div class="wp-block-group alignwide" style="padding-bottom:60px"><!-- wp:heading {"align":"wide","fontSize":"level-5"} -->
-<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'New to WordPress?', 'wporg' ) . '</h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading {"align":"wide","style":{"typography":{"lineHeight":0.1}},"fontSize":"level-5"} -->
-<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder" style="line-height:0.1">' . esc_html__( 'No problem.', 'wporg' ) . '</h2>
+<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'New to WordPress?', 'wporg' ) . '<br>' . esc_html__( 'No problem.', 'wporg' ) . '</h2>
 <!-- /wp:heading --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
@@ -242,7 +242,7 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-columns" style="padding-right:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"top","width":"53%","style":{"spacing":{"padding":{"bottom":"0px"}}}} -->
 <div class="wp-block-column is-vertically-aligned-top" style="padding-bottom:0px;flex-basis:53%"><!-- wp:group {"align":"wide","className":"wporg-gutenberg-block-layout","layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide wporg-gutenberg-block-layout"><!-- wp:heading {"align":"wide","fontSize":"level-5"} -->
-<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'Give your creativity a head start.', 'wporg' ) . '</h2>
+<h2 class="alignwide has-level-5-font-size" id="head-start">' . esc_html__( 'Give your creativity a head start.', 'wporg' ) . '</h2>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":"40px","className":"wporg-gutenberg-hide-on-mobile"} -->
@@ -408,7 +408,7 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column {"width":"80%"} -->
 <div class="wp-block-column" style="flex-basis:80%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"60px"}}},"layout":{"contentSize":""}} -->
 <div class="wp-block-group alignwide" style="padding-bottom:60px"><!-- wp:heading {"align":"wide","fontSize":"level-5"} -->
-<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'New to WordPress?', 'wporg' ) . '<br>' . esc_html__( 'No problem.', 'wporg' ) . '</h2>
+<h2 class="alignwide has-level-5-font-size" id="new-to-wordpress">' . esc_html__( 'New to WordPress?', 'wporg' ) . '<br>' . esc_html__( 'No problem.', 'wporg' ) . '</h2>
 <!-- /wp:heading --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content.php
@@ -408,11 +408,7 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column {"width":"80%"} -->
 <div class="wp-block-column" style="flex-basis:80%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"60px"}}},"layout":{"contentSize":""}} -->
 <div class="wp-block-group alignwide" style="padding-bottom:60px"><!-- wp:heading {"align":"wide","fontSize":"level-5"} -->
-<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'New to WordPress?', 'wporg' ) . '</h2>
-<!-- /wp:heading -->
-
-<!-- wp:heading {"align":"wide","style":{"typography":{"lineHeight":0.1}},"fontSize":"level-5"} -->
-<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder" style="line-height:0.1">' . esc_html__( 'No problem.', 'wporg' ) . '</h2>
+<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'New to WordPress?', 'wporg' ) . '<br>' . esc_html__( 'No problem.', 'wporg' ) . '</h2>
 <!-- /wp:heading --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->

--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content.php
@@ -242,7 +242,7 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-columns" style="padding-right:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"top","width":"53%","style":{"spacing":{"padding":{"bottom":"0px"}}}} -->
 <div class="wp-block-column is-vertically-aligned-top" style="padding-bottom:0px;flex-basis:53%"><!-- wp:group {"align":"wide","className":"wporg-gutenberg-block-layout","layout":{"type":"default"}} -->
 <div class="wp-block-group alignwide wporg-gutenberg-block-layout"><!-- wp:heading {"align":"wide","fontSize":"level-5"} -->
-<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'Give your creativity a head start.', 'wporg' ) . '</h2>
+<h2 class="alignwide has-level-5-font-size" id="head-start">' . esc_html__( 'Give your creativity a head start.', 'wporg' ) . '</h2>
 <!-- /wp:heading -->
 
 <!-- wp:spacer {"height":"40px","className":"wporg-gutenberg-hide-on-mobile"} -->
@@ -408,7 +408,7 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-columns is-not-stacked-on-mobile"><!-- wp:column {"width":"80%"} -->
 <div class="wp-block-column" style="flex-basis:80%"><!-- wp:group {"align":"wide","style":{"spacing":{"padding":{"bottom":"60px"}}},"layout":{"contentSize":""}} -->
 <div class="wp-block-group alignwide" style="padding-bottom:60px"><!-- wp:heading {"align":"wide","fontSize":"level-5"} -->
-<h2 class="alignwide has-level-5-font-size" id="be-your-own-builder">' . esc_html__( 'New to WordPress?', 'wporg' ) . '<br>' . esc_html__( 'No problem.', 'wporg' ) . '</h2>
+<h2 class="alignwide has-level-5-font-size" id="new-to-wordpress">' . esc_html__( 'New to WordPress?', 'wporg' ) . '<br>' . esc_html__( 'No problem.', 'wporg' ) . '</h2>
 <!-- /wp:heading --></div>
 <!-- /wp:group --></div>
 <!-- /wp:column -->


### PR DESCRIPTION
## Summary
Closes #53 

## Description
This PR merges the `New to WordPress?` and `No problem.` texts into one heading.
The ID `be-your-own-builder` was being used in various header tags so they were updated with a unique ID.

## Testing
- Validate that there are no longer headings with the same ID.
- Validate that the text `New to WordPress?` and `No problem.` are under only one header tag.