### PR TITLE
remove hand with book icon

### DIFF
--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
@@ -461,7 +461,7 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-cover alignfull is-light" style="padding-top:60px;padding-bottom:60px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#fdfdfd"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"contentSize":"1200px"}} -->
 <div class="wp-block-group"><!-- wp:columns {"verticalAlignment":"center","isStackedOnMobile":false,"style":{"spacing":{"padding":{"top":"0px","bottom":"0px","right":"0px","left":"0px"}}}} -->
 <div class="wp-block-columns are-vertically-aligned-center is-not-stacked-on-mobile" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"80%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:80%"><!-- wp:paragraph {"fontSize":"level-2"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:100%"><!-- wp:paragraph {"fontSize":"level-2"} -->
 <p class="has-level-2-font-size">' . esc_html__( 'Some more helpful content and places to dig deeper about Gutenberg.', 'wporg' ) . '</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>

--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content-mobile.php
@@ -464,12 +464,6 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:80%"><!-- wp:paragraph {"fontSize":"level-2"} -->
 <p class="has-level-2-font-size">' . esc_html__( 'Some more helpful content and places to dig deeper about Gutenberg.', 'wporg' ) . '</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"verticalAlignment":"center","width":"20%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:20%"><!-- wp:image {"align":"right","id":1157,"width":85,"height":85,"sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"unset"}}} -->
-<figure class="wp-block-image alignright size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022/10/docs.png" alt="" class="wp-image-1157" width="85" height="85"/></figure>
-<!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 

--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content.php
@@ -461,7 +461,7 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-cover alignfull is-light" style="padding-top:60px;padding-bottom:60px"><span aria-hidden="true" class="wp-block-cover__background has-background-dim-100 has-background-dim" style="background-color:#fdfdfd"></span><div class="wp-block-cover__inner-container"><!-- wp:group {"layout":{"contentSize":"1200px"}} -->
 <div class="wp-block-group"><!-- wp:columns {"verticalAlignment":"center","isStackedOnMobile":false,"style":{"spacing":{"padding":{"top":"0px","bottom":"0px","right":"0px","left":"0px"}}}} -->
 <div class="wp-block-columns are-vertically-aligned-center is-not-stacked-on-mobile" style="padding-top:0px;padding-right:0px;padding-bottom:0px;padding-left:0px"><!-- wp:column {"verticalAlignment":"center","width":"80%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:80%"><!-- wp:paragraph {"fontSize":"level-2"} -->
+<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:100%"><!-- wp:paragraph {"fontSize":"level-2"} -->
 <p class="has-level-2-font-size">' . esc_html__( 'Some more helpful content and places to dig deeper about Gutenberg.', 'wporg' ) . '</p>
 <!-- /wp:paragraph --></div>
 <!-- /wp:column --></div>

--- a/source/wp-content/themes/wporg-gutenberg/gutenberg-content.php
+++ b/source/wp-content/themes/wporg-gutenberg/gutenberg-content.php
@@ -464,12 +464,6 @@ $content = '<!-- wp:group {"align":"full","layout":{"inherit":false,"contentSize
 <div class="wp-block-column is-vertically-aligned-center" style="flex-basis:80%"><!-- wp:paragraph {"fontSize":"level-2"} -->
 <p class="has-level-2-font-size">' . esc_html__( 'Some more helpful content and places to dig deeper about Gutenberg.', 'wporg' ) . '</p>
 <!-- /wp:paragraph --></div>
-<!-- /wp:column -->
-
-<!-- wp:column {"verticalAlignment":"center","width":"20%"} -->
-<div class="wp-block-column is-vertically-aligned-center" style="flex-basis:20%"><!-- wp:image {"align":"right","id":1157,"width":85,"height":85,"sizeSlug":"full","linkDestination":"none","style":{"color":{"duotone":"unset"}}} -->
-<figure class="wp-block-image alignright size-full is-resized"><img src="https://wordpress.org/gutenberg/files/2022/10/docs.png" alt="" class="wp-image-1157" width="85" height="85"/></figure>
-<!-- /wp:image --></div>
 <!-- /wp:column --></div>
 <!-- /wp:columns -->
 


### PR DESCRIPTION
Summary

Closes https://github.com/WordPress/wporg-gutenberg/issues/54

Description

Removed the image, column and DIV from the content and content-mobile files.

Testing

Validate that the hand with book image has been removed from the main content page.