### PR TITLE
Fix null post warning in add_social_meta_tags()

### DIFF
--- a/source/wp-content/themes/wporg-gutenberg/functions.php
+++ b/source/wp-content/themes/wporg-gutenberg/functions.php
@@ -743,7 +743,11 @@ add_action( 'wp_enqueue_scripts', 'gutenbergtheme_scripts' );
  * Add meta tags for richer social media integrations.
  */
 function add_social_meta_tags() {
-	$post          = get_post();
+	$post = get_post();
+	if ( ! $post ) {
+		return;
+	}
+
 	$excerpt       = get_the_excerpt( $post );
 	$default_image = wp_get_attachment_url( get_post_thumbnail_id( $post->ID ), 'thumbnail' );
 	$site_title    = function_exists( '\WordPressdotorg\site_brand' ) ? \WordPressdotorg\site_brand() : 'WordPress.org';


### PR DESCRIPTION
## Summary
- Adds a null check for `get_post()` in `add_social_meta_tags()` before accessing `$post->ID`
- The function hooks into `wp_head`, which fires on the `global-header-footer/v1/header` REST endpoint where no post context exists
- Fixes `E_WARNING: Attempt to read property "ID" on null`

## Test plan
- [ ] Request `GET /gutenberg/wp-json/global-header-footer/v1/header` — no PHP warning
- [ ] Visit `wordpress.org/gutenberg/` — social meta tags still present in `<head>`