### PR TITLE
Blocks: Migrate demo button and link to Block API version 3

### DIFF
--- a/source/wp-content/themes/wporg-gutenberg/blocks/button/button.js
+++ b/source/wp-content/themes/wporg-gutenberg/blocks/button/button.js
@@ -1,9 +1,11 @@
 var el = wp.element.createElement,
 	registerBlockType = wp.blocks.registerBlockType,
 	InnerBlocks = wp.blockEditor.InnerBlocks,
+	useBlockProps = wp.blockEditor.useBlockProps,
 	isAdmin = window.location.pathname.includes( 'wp-admin' );
 
 registerBlockType( 'wporg/wporg-gutenberg-button', {
+	apiVersion: 3,
 	title: 'Demo Button',
 	icon: 'button',
 	category: 'layout',
@@ -30,18 +32,20 @@ registerBlockType( 'wporg/wporg-gutenberg-button', {
 	},
 
 	edit( props ) {
+		const blockProps = useBlockProps();
+
 		if ( ! isAdmin ) {
 			const blockEditorData = wp.data.select( 'core/block-editor' );
 			const innerHtml = blockEditorData.getBlock( props.clientId ).innerBlocks[ 0 ].originalContent;
 
 			return el( 'div', {
-				className: props.className,
+				...blockProps,
 				dangerouslySetInnerHTML: { __html: innerHtml },
 			} );
 		}
 		return el(
 			'div',
-			{ className: props.className },
+			blockProps,
 			el( InnerBlocks, {
 				template: [ [ 'core/button' ] ],
 				templateLock: 'all',
@@ -50,6 +54,10 @@ registerBlockType( 'wporg/wporg-gutenberg-button', {
 	},
 
 	save() {
-		return el( 'div', { className: 'wp-block-buttons' }, el( InnerBlocks.Content ) );
+		return el(
+			'div',
+			useBlockProps.save( { className: 'wp-block-buttons' } ),
+			el( InnerBlocks.Content )
+		);
 	},
 } );

--- a/source/wp-content/themes/wporg-gutenberg/blocks/link/link.js
+++ b/source/wp-content/themes/wporg-gutenberg/blocks/link/link.js
@@ -1,9 +1,11 @@
 var el = wp.element.createElement,
 	registerBlockType = wp.blocks.registerBlockType,
 	InnerBlocks = wp.blockEditor.InnerBlocks,
+	useBlockProps = wp.blockEditor.useBlockProps,
 	isAdmin = window.location.pathname.includes( 'wp-admin' );
 
 registerBlockType( 'wporg/wporg-gutenberg-link', {
+	apiVersion: 3,
 	title: 'Demo Link',
 	description: 'Create a link for the demo page.',
 	icon: 'button',
@@ -14,18 +16,20 @@ registerBlockType( 'wporg/wporg-gutenberg-link', {
 	},
 
 	edit( props ) {
+		const blockProps = useBlockProps();
+
 		if ( ! isAdmin ) {
 			const blockEditorData = wp.data.select( 'core/block-editor' );
 			const innerHtml = blockEditorData.getBlock( props.clientId ).innerBlocks[ 0 ].originalContent;
 
 			return el( 'div', {
-				className: props.className,
+				...blockProps,
 				dangerouslySetInnerHTML: { __html: innerHtml },
 			} );
 		}
 		return el(
 			'div',
-			{ className: props.className },
+			blockProps,
 			el( InnerBlocks, {
 				template: [ [ 'core/paragraph' ] ],
 				templateLock: 'all',
@@ -34,6 +38,6 @@ registerBlockType( 'wporg/wporg-gutenberg-link', {
 	},
 
 	save() {
-		return el( 'div', {}, el( InnerBlocks.Content ) );
+		return el( 'div', useBlockProps.save(), el( InnerBlocks.Content ) );
 	},
 } );


### PR DESCRIPTION
## What

Registers the two demo blocks (`wporg/wporg-gutenberg-button` and `wporg/wporg-gutenberg-link`) with `apiVersion: 3` and adopts the accompanying `useBlockProps` requirements.

## Why

Both blocks were registered without an `apiVersion`, so they defaulted to version **1**. Since WordPress 6.9 this logs a deprecation warning in the editor console:

> Block with API version 2 or lower is deprecated since version 6.9. … The block `"wporg/wporg-gutenberg-button"` is registered with API version 1. This means that the post editor may work as a non-iframe editor. Since all editors are planned to work as iframes in the future, set the `apiVersion` field to 3 and test the block inside the iframe editor.

A single block below API v3 keeps the entire post editor out of the iframe, and [all editors are planned to always be iframed in WordPress 7.0](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/). See the [iframe migration guide](https://developer.wordpress.org/block-editor/reference-guides/block-api/block-api-versions/block-migration-for-iframe-editor-compatibility/).

## Changes

- `apiVersion: 3` on both block registrations.
- `edit`: call `useBlockProps()` once, unconditionally, at the top so both the admin and Frontenberg (logged-out) render branches apply it to the wrapper.
- `save`: use `useBlockProps.save()`. In API v2+ the generated `wp-block-wporg-wporg-gutenberg-*` class is **no longer auto-injected** into saved markup, so this is required — both to keep the class the theme's `style.css` targets, and to keep the serialized output byte-for-byte equivalent (same class set) so existing saved content does not fail block validation.

Neither block accesses `window`/`document` or the DOM directly (they read from the `core/block-editor` data store), so no further iframe-compatibility work is needed.

## Testing

- Confirm the two blocks no longer emit the API-version deprecation warning in the editor console.
- Verify the demo button/link render correctly in both the admin editor and the logged-out Frontenberg editor, and that existing demo content loads without a block-validation ("unexpected or invalid content") notice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)